### PR TITLE
Fixed error that was creating 4D eroded brain masks

### DIFF
--- a/x.PreProc_BET-4D
+++ b/x.PreProc_BET-4D
@@ -56,8 +56,9 @@ then
   echo "**************************************************"
   echo "Eroding edges from ${input_prefix}_bet.nii.gz"
   echo "**************************************************"
-  fslmaths "${output_dir}/${input_prefix}_bet.nii.gz" -ero "${output_dir}/${input_prefix}_bet_ero.nii.gz"
-  fslmaths "${output_dir}/${input_prefix}_bet.nii.gz" -bin "${output_dir}/${input_prefix}_bet_ero_mask.nii.gz"
+  fslmaths "${output_dir}/${input_prefix}_bet_mask.nii.gz" -ero "${output_dir}/${input_prefix}_bet_mask_ero.nii.gz"
+  3dcalc -a "${output_dir}/${input_prefix}_bet.nii.gz" -b "${output_dir}/${input_prefix}_bet_mask_ero.nii.gz" -expr "a*b" -prefix "${output_dir}/${input_prefix}_bet_ero.nii.gz"
+
 
 else
   echo "**********************************************************"


### PR DESCRIPTION
Now, to generate an eroded brain mask and 4D dataset:
1. The bet mask is eroded
2. The output of step (1) is applied to the brain extracted 4D dataset
Note that this slightly changes our file naming conventions. The brain mask we most commonly use now ends with "bet_mask_ero" instead of "bet_ero_mask"