### PR TITLE
Add registration and distortion correction code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This collection of code assumes you have a fMRI file and a T1-weighted file in n
 It does minimal pre-processing of the fMRI data and produces tissue masks in fMRI space, and outputs average time-series over these masks.
 If you have collected reverse phase encode scans which allow you to make field maps it also performs distortion correction of the fMRI file.
 
-There are 15 functions. Each function can be run separately but the recommended way to run all of these functions is to write some parent code that can loop over subjects or scans, calling upon each individual function. A template for this can be seen in the file 'x.PreProc_RUN_Template' in this repo. The suggested way to interact with these functions is to only copy the x.PreProc_RUN_Template into your own repo, rename it something related to your project, and make edits to this RUN file only, calling upon the functions in this repo but not changing these individual functions.
+Each function can be run separately but the recommended way to run all of these functions is to write some parent code that can loop over subjects or scans, calling upon each individual function. A template for this can be seen in the file 'x.PreProc_RUN_Template' in this repo. The suggested way to interact with these functions is to only copy the x.PreProc_RUN_Template into your own repo, rename it something related to your project, and make edits to this RUN file only, calling upon the functions in this repo but not changing these individual functions.
 
 Suggested order to run:
 
@@ -12,13 +12,16 @@ Suggested order to run:
 2. x.PreProc_SEG-anat (tissue segmentation on anatomical dataset)
 (An alternative to 1 and 2 would be to run fsl_anat which has further features)
 3. x.PreProc_VolReg_4D (motion correction on functional dataset)
-OR x.PreProc_VolReg_4D_ME (motion correction on multi-echo functional dataset)
+  - multi-echo: x.PreProc_VolReg_4D_ME
 4. x.PreProc_DistortCorrect (make field map and perform distortion correction using reverse phase encode scan) **Think about whether it makes sense to do this as step 4 in your dataset. It may depend on what inputs you use and what your reference is for VolReg_4D**
-OR x.PreProc_fmapPrep (make field map using Siemens field map scan; this can be run anytime after anatomical processing and before TissueReg)
+  - OR x.PreProc_fmapPrep (make field map using Siemens field map scan; this can be run anytime after anatomical processing and before TissueReg)
+  - multi-echo: x.PreProc_DistortCorrect_ME OR x.PreProc_DistortCorrect_FUGUE_ME (w/ x.PreProc_fmapPrep and x.PreProc_TissueReg_func2anat_fmap)
 5. x.PreProc_BET-4D (brain extraction on functional dataset) OR x.PreProc_Mask-4D (apply the brain mask made from running x.PreProc_BET-4D on a different functional scan in the same space)
 6. x.PreProc_TissueReg_func2anat (register functional and anatomical datasets)
 OR x.PreProc_TissueReg_func2anat_fmap (register functional and anatomical datasets, incorporating distortion correction from Siemens field map created in x.PreProc_fmapPrep)
-7. x.PreProc_TissueReg_func2stand (register functional/anatomical and standard datasets)
-8. x.PreProc_Transform_lin (linear transformation of functional <-> anatomical space)
-9. x.PreProc_Transform_nonlin (nonlinear transformation of functional <-> standard space)
-10. x.PreProc_MEANTS (output a mean time-series from the functional dataset, masked by a tissue mask)
+7. x.PreProc_TissueReg_anat2stand (register anatomical and standard datasets; incorporates lesion mask if needed)
+8. x.PreProc_TissueReg_func2stand (register functional/anatomical and standard datasets)
+  - OR x.PreProc_TissueReg_func2standConcat (concatenate func2anat with anat2stand)
+9. x.PreProc_Transform_lin (linear transformation of functional <-> anatomical space)
+10. x.PreProc_Transform_nonlin (nonlinear transformation of functional <-> standard space)
+11. x.PreProc_MEANTS (output a mean time-series from the functional dataset, masked by a tissue mask)

--- a/x.PreProc_DistortCorrect_FUGUE_ME.sh
+++ b/x.PreProc_DistortCorrect_FUGUE_ME.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# x.PreProc_DistortCorrect_FUGUE_ME.sh
+
+# Converts a distorted functional space image to undistorted functional space
+# Uses FUGUE in FSL
+# Must have already run x.PreProc_TissueReg_func2anat_fmap.sh to get field map in radians and functional space
+
+if [ $# -ne 4 ]
+then
+    echo "********************************************************************************************************"
+    echo "Insufficient arguments supplied"
+    echo "Input 1 should be the full path to distorted functional image"
+    echo "Input 2 should be the effective echo spacing (dwell time) in seconds"
+    echo "Input 3 should be the field map in radians and functional space, ex. _fieldmaprads2epi"
+    echo "Input 4 should be the full path to the output directory"
+    echo "*Note: do not include file extension - assumes nii.gz"
+    echo "********************************************************************************************************"
+    exit
+fi
+
+#define inputs
+input_file_func_dist=${1}
+dwelltime=${2}
+input_file_fieldmap=${3}
+output_dir=${4}
+
+#Check the input files exist
+echo "*******************************************************"
+echo "Input files are ${input_file_func_dist} and ${input_file_fieldmap}"
+echo "*******************************************************"
+if [ ! -f "${input_file_func_dist}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the transformation matrix ${input_file_func_dist}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_fieldmap}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_fieldmap}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+
+#If output directory is not present, make it
+if [ ! -d ${output_dir} ]
+then
+  mkdir ${output_dir}
+fi
+echo "********************************"
+echo "Output directory is ${output_dir}"
+echo "********************************"
+
+#Get the input filename without the path
+input_prefix="$(basename -- $input_file_func_dist)"
+
+
+if [ ! -f ${output_dir}/${input_prefix}_dc.nii.gz ]
+then
+
+  echo "*******************************************************************"
+  echo "Distortion correcting ${input_file_func_dist} with FSL FUGUE"
+  echo "*******************************************************************"
+
+  fugue -i ${input_file_func_dist}.nii.gz --dwell=${dwelltime} --loadfmap=${input_file_fieldmap}.nii.gz -u ${output_dir}/${input_prefix}_dc.nii.gz
+
+else
+ echo "***********************************************************************"
+ echo "Distortion correction of ${input_file_func_dist} already completed"
+ echo "***********************************************************************"
+fi

--- a/x.PreProc_DistortCorrect_ME.sh
+++ b/x.PreProc_DistortCorrect_ME.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+
+# x.PreProc_DistortCorrect_ME.sh
+
+# Makes a field map based on two input volumes with different phase encode directions, and then uses this to perform distortion correction on a 4D BOLD-EPI file.
+
+# Some resources:
+# https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/topup/TopupUsersGuide
+# https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/topup/ApplyTopupUsersGuide
+# Typically. this FSL pipeline seems to be written for SE-EPI data, we have GE-EPI data with more signal loss
+# This paper suggests that it is still valid with GE-EPI: https://www.frontiersin.org/articles/10.3389/fnins.2021.642808/full
+# It seems to work, see the video 'DistortCorrect_singleTE_GE-bold.mov' in this repo for example output)
+
+# There are lots of ways to make field maps and perform distortion correction, please check this function is appropriate for your data!
+# This function was written based on acquiring two scans:
+# [1] - A 4D BOLD EPI multi-band scan with AP phase encoding which also outputs a Single Band Reference Image (SBRef) volume. Your scan of interest!
+# [2] - A scan with identical parameters as [1] but just a single volume & with PA phase encoding -  this also outputs a SBRef volume.
+# Scan [2] was acquired just before scan [1], as close as possible in time.
+# The SBRef volume for scan [1] is used as the reference (base) volume in the x.PreProc_VolReg-4D function, to correct for motion.
+# The SBRef volumes from scan [1] and scan [2] are used to make the field map.
+# This field map can then be used to correct geometric distortions in the 4D BOLD EPI multi-band scan [1].
+
+
+if [ $# -ne 6 ]
+then
+    echo "**************************************************************************************"
+    echo "Insufficient arguments supplied"
+    echo "Input 1 should be the full path to the AP file, used to make the fieldmap"
+    echo "Input 2 should be the full path to the PA file, used to make the fieldmap"
+    echo "Input 3 should be the full path to the 4D-fMRI file (AP) to correct for distortion (w/o echo number suffix)"
+    echo "Input 4 should be the number of echoes collected"
+    echo "Input 5 should be the full path to the text file with PE directions/times (line1: AP, line2: PA)"
+    echo "Input 6 should be the output directory for the fieldmap files e.g. fieldmap_files_sub01"
+    echo "*Do not include file extension - assumes nii.gz for inputs 1-3 and txt for 5*"
+    echo "**************************************************************************************"
+    exit
+fi
+
+#define inputs
+AP_file=${1}
+PA_file=${2}
+File_4D=${3}
+num_echoes=${4}
+topup_file=${5}
+output_dir=${6}
+
+#Check the input files exists
+echo "***********************************"
+echo "Input AP file is ${AP_file}.nii.gz"
+echo "***********************************"
+if [ ! -f "${AP_file}.nii.gz" ]
+then
+  echo "****************************************************"
+  echo "Cannot locate the NIFTI input file ${AP_file}.nii.gz"
+  echo "...exiting!"
+  echo "****************************************************"
+  exit
+fi
+
+echo "Input PA file is ${PA_file}.nii.gz"
+echo "**********************************"
+if [ ! -f "${PA_file}.nii.gz" ]
+then
+  echo "Cannot locate the NIFTI input file ${PA_file}.nii.gz"
+  echo "...exiting!"
+  echo "****************************************************"
+  exit
+fi
+
+echo "Input 4D file is ${File_4D}.nii.gz"
+echo "**********************************"
+if [ ! -f "${File_4D}_1.nii.gz" ]
+then
+  echo "Cannot locate the NIFTI input file ${File_4D}_1.nii.gz"
+  echo "...exiting!"
+  echo "****************************************************"
+  exit
+fi
+
+#If output directory is not present, make it
+if [ ! -d ${output_dir} ]
+then
+  mkdir -p ${output_dir}
+fi
+echo "Output directory is ${output_dir}"
+echo "********************************"
+
+
+# Merge into one file
+if [ ! -f "${output_dir}/AP_PA_merge.nii.gz" ]
+then
+  echo "Merging AP and PA input volumes"
+  echo "*******************************"
+  fslmerge -t ${output_dir}/AP_PA_merge.nii.gz ${AP_file}.nii.gz ${PA_file}.nii.gz
+else
+  echo "AP and PA input volumes already merged"
+  echo "*******************************"
+fi
+
+# Make fieldmap
+if [ ! -f "${output_dir}/my_topup_results_fieldcoef.nii.gz" ] #just checking for the main output
+then
+  echo "Running topup (making fieldmap)"
+  echo "*******************************"
+  topup --imain=${output_dir}/AP_PA_merge.nii.gz --datain=${topup_file}.txt --config=b02b0.cnf --out=${output_dir}/my_topup_results --fout=${output_dir}/my_field --iout=${output_dir}/my_unwarped_image
+else
+  echo "topup already run (fieldmaps already made)"
+  echo "******************************************"
+fi
+
+#Get the input filename without the path
+input_prefix="$(basename -- $File_4D)"
+input_prefix2="$(basename -- $AP_file)"
+
+# Apply field map for distortion correction
+if [ ! -f "${File_4D}_dc_1.nii.gz" ]
+then
+  echo "Applying topup (distortion correction)"
+  echo "**************************************"
+  for echonum in $(eval echo "{1..$num_echoes}")
+  do
+    applytopup --imain=${File_4D}_${echonum}.nii.gz --inindex=1 --topup=${output_dir}/my_topup_results --datain=${topup_file}.txt --out=${output_dir}/${input_prefix}_dc_${echonum}.nii.gz  --method=jac
+  done
+
+  applytopup --imain=${AP_file}.nii.gz --inindex=1 --topup=${output_dir}/my_topup_results --datain=${topup_file}.txt --out=${output_dir}/${input_prefix2}_dc.nii.gz  --method=jac
+else
+  echo "Topup (distortion correction) already completed"
+  echo "***********************************************"
+fi

--- a/x.PreProc_TissueReg_anat2stand.sh
+++ b/x.PreProc_TissueReg_anat2stand.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# x.PreProc_TissueReg_anat2stand.sh
+
+# Registers an image in anatomical space to standard space
+# Outputs are transformation matrices for anat2stand and stand2anat
+# Uses FNIRT in FSL (nonlinear)
+# Currently works only for 2mm MNI space. To use with a different standard, will have to find a different --config file to use with FNIRT
+
+if [ $# -ne 8 ]
+then
+    echo "********************************************************************************************************"
+    echo "Insufficient arguments supplied"
+    echo "Input 1 should be the full path to the anat input scan (brain extracted)"
+    echo "Input 2 should be the full path to the anat input scan (NOT brain extracted)"
+    echo "Input 3 should be the full path to the standard input scan, ex. MNI152_T1_2mm_brain (brain extracted)"
+    echo "Input 4 should be the full path to the standard input scan, ex. MNI152_T1_2mm (NOT brain extracted)"
+    echo "Input 5 should be the full path to the standard brain mask, ex. MNI152_T1_2mm_brain_mask_dil"
+    echo "Input 6 should be the full path to the output directory"
+    echo "Input 7 should be the subject ID"
+    echo "Input 8 should be the lesion mask in anat space (input 0 if no lesion mask)"
+    echo "*Note: do not include file extension - assumes nii.gz and .mat"
+    echo "********************************************************************************************************"
+    exit
+fi
+
+#define inputs
+input_file_anat_brain=${1}
+input_file_anat=${2}
+input_file_stand_brain=${3}
+input_file_stand=${4}
+input_file_stand_mask=${5}
+output_dir=${6}
+subject=${7}
+lesion_mask="${8}"
+
+#Check the input files exist
+echo "*******************************************************"
+echo "Input files are ${input_file_anat_brain} and ${input_file_anat} and ${input_file_stand_brain} and ${input_file_stand} and ${input_file_stand_mask}"
+echo "*******************************************************"
+
+if [ ! -f "${input_file_anat_brain}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_anat_brain}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_anat}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_anat}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_stand_brain}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_stand_brain}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_stand}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_stand}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_stand_mask}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_stand_mask}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+#If output directory is not present, make it
+if [ ! -d ${output_dir} ]
+then
+  mkdir ${output_dir}
+fi
+echo "********************************"
+echo "Output directory is ${output_dir}"
+echo "********************************"
+
+
+#Registration from anat to stand
+
+if [ ! -f ${output_dir}/${subject}_stand2anat_warp.nii.gz ]
+then
+  if [ ${lesion_mask} == "0" ]
+  then
+
+    echo "***********************************************************************************"
+    echo "Registering ${input_file_anat_brain} to ${input_file_stand_brain} with FSL FNIRT"
+    echo "***********************************************************************************"
+
+    # stuctural <-> standard
+    flirt -in ${input_file_anat_brain}.nii.gz -ref ${input_file_stand_brain}.nii.gz -out ${output_dir}/${subject}_anat2stand -omat ${output_dir}/${subject}_anat2stand.mat -cost corratio -dof 12 \
+      -searchrx -90 90 -searchry -90 90 -searchrz -90 90 -interp trilinear
+    fnirt --iout=${output_dir}/${subject}_anat2stand_head --in=${input_file_anat}.nii.gz --aff=${output_dir}/${subject}_anat2stand.mat --cout=${output_dir}/${subject}_anat2stand_warp \
+      --iout=${output_dir}/${subject}_anat2stand --jout=${output_dir}/${subject}_anat2anat_jac --config=T1_2_MNI152_2mm --ref=${input_file_stand}.nii.gz --refmask=${input_file_stand_mask}.nii.gz --warpres=5,5,5
+    applywarp -i ${input_file_anat_brain}.nii.gz -r ${input_file_stand_brain}.nii.gz -o ${output_dir}/${subject}_anat2stand.nii.gz -w ${output_dir}/${subject}_anat2stand_warp
+    convert_xfm -inverse -omat ${output_dir}/${subject}_stand2anat.mat ${output_dir}/${subject}_anat2stand.mat
+
+    echo "*******************************"
+    echo "Inverting warp"
+    echo "*******************************"
+    invwarp --ref=${input_file_anat_brain}.nii.gz --warp=${output_dir}/${subject}_anat2stand_warp --out=${output_dir}/${subject}_stand2anat_warp
+  else
+    echo "***************************************************************************************************"
+    echo "Registering ${input_file_anat_brain} to ${input_file_stand_brain} with FSL FNIRT using lesion mask ${lesion_mask}"
+    echo "***************************************************************************************************"
+
+    # stuctural <-> standard
+    flirt -in ${input_file_anat_brain}.nii.gz -ref ${input_file_stand_brain}.nii.gz -out ${output_dir}/${subject}_anat2stand -omat ${output_dir}/${subject}_anat2stand.mat -cost corratio -dof 12 \
+      -searchrx -90 90 -searchry -90 90 -searchrz -90 90 -interp trilinear
+    fnirt --iout=${output_dir}/${subject}_anat2stand_head --in=${input_file_anat}.nii.gz --aff=${output_dir}/${subject}_anat2stand.mat --cout=${output_dir}/${subject}_anat2stand_warp \
+      --iout=${output_dir}/${subject}_anat2stand --jout=${output_dir}/${subject}_anat2anat_jac --config=T1_2_MNI152_2mm --ref=${input_file_stand}.nii.gz --refmask=${input_file_stand_mask}.nii.gz --warpres=5,5,5 \
+      --inmask=${lesion_mask}.nii.gz
+    applywarp -i ${input_file_anat_brain}.nii.gz -r ${input_file_stand_brain}.nii.gz -o ${output_dir}/${subject}_anat2stand.nii.gz -w ${output_dir}/${subject}_anat2stand_warp
+    convert_xfm -inverse -omat ${output_dir}/${subject}_stand2anat.mat ${output_dir}/${subject}_anat2stand.mat
+
+    echo "*******************************"
+    echo "Inverting warp"
+    echo "*******************************"
+    invwarp --ref=${input_file_anat_brain}.nii.gz --warp=${output_dir}/${subject}_anat2stand_warp --out=${output_dir}/${subject}_stand2anat_warp
+  fi
+else
+ echo "***********************************************************************"
+ echo "Registration from func to ${input_file_stand_brain} already completed"
+ echo "***********************************************************************"
+fi

--- a/x.PreProc_TissueReg_func2standConcat.sh
+++ b/x.PreProc_TissueReg_func2standConcat.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+# x.PreProc_TissueReg_func2standConcat.sh
+
+# Concatenates previously created func2anat and anat2stand files
+# Outputs are transformation matrices for funcstand and stand2func
+
+if [ $# -ne 8 ]
+then
+    echo "********************************************************************************************************"
+    echo "Insufficient arguments supplied"
+    echo "Input 1 should be the full path to the func2anat transformation matrix"
+    echo "Input 2 should be the full path to the anat2func transformation matrix"
+    echo "Input 3 should be the full path to the anat2stand transformation warp"
+    echo "Input 4 should be the full path to the stand2anat transformation warp"
+    echo "Input 5 should be the full path to the functional reference image (brain extracted)"
+    echo "Input 6 should be the full path to the standard reference image (brain extracted)"
+    echo "Input 7 should be the full path to the output directory"
+    echo "Input 8 should be the subject ID"
+    echo "*Note: do not include file extension - assumes nii.gz and .mat"
+    echo "********************************************************************************************************"
+    exit
+fi
+
+#define inputs
+input_file_func2anat=${1}
+input_file_anat2func=${2}
+input_file_anat2stand=${3}
+input_file_stand2anat=${4}
+input_file_funcref=${5}
+input_file_standref=${6}
+output_dir=${7}
+subject=${8}
+
+#Check the input files exist
+echo "*******************************************************"
+echo "Input files are ${input_file_func2anat} and ${input_file_anat2func} and ${input_file_anat2stand} and ${input_file_stand2anat} and ${input_file_funcref} and ${input_file_standref}"
+echo "*******************************************************"
+
+if [ ! -f "${input_file_func2anat}.mat" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the transformation matrix ${input_file_func2anat}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_anat2func}.mat" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the transformation matrix ${input_file_anat2func}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_anat2stand}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_anat2stand}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_stand2anat}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_stand2anat}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_funcref}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_funcref}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+if [ ! -f "${input_file_standref}.nii.gz" ]
+then
+  echo "***************************************************"
+  echo "Cannot locate the NIFTI input file ${input_file_standref}"
+  echo "...exiting!"
+  echo "***************************************************"
+  exit
+fi
+
+#If output directory is not present, make it
+if [ ! -d ${output_dir} ]
+then
+  mkdir ${output_dir}
+fi
+echo "********************************"
+echo "Output directory is ${output_dir}"
+echo "********************************"
+
+
+#Registration from anat to stand
+
+if [ ! -f ${output_dir}/${subject}_stand2func_warp.nii.gz ]
+then
+
+    echo "***********************************************************************************"
+    echo "Concatenating ${input_file_func2anat} with ${input_file_anat2stand}"
+    echo "***********************************************************************************"
+
+    convertwarp --ref=${input_file_standref}.nii.gz --premat=${input_file_func2anat}.mat --warp1=${input_file_anat2stand}.nii.gz --out=${output_dir}/${subject}_func2stand_warp.nii.gz
+
+    echo "***********************************************************************************"
+    echo "Concatenating ${input_file_stand2anat} with ${input_file_anat2func}"
+    echo "***********************************************************************************"
+
+    convertwarp --ref=${input_file_funcref}.nii.gz --warp1=${input_file_stand2anat}.nii.gz --postmat=${input_file_anat2func}.mat --out=${output_dir}/${subject}_stand2func_warp.nii.gz
+
+else
+ echo "***********************************************************************"
+ echo "Concatenation of transformation files already completed"
+ echo "***********************************************************************"
+fi


### PR DESCRIPTION
1. Add an option to do anat2stand distortion correction separately from the current func2stand code, which does both func2anat and anat2stand in the same script. This is helpful for datasets in which one subject has multiple functional scans, so the anat2stand registration does not need to be run multiple times.
- x.PreProc_TissueReg_anat2stand
- x.PreProc_TissueReg_func2standConcat (concatenates previously created func2anat and anat2stand files)
2. Add distortion correction code
- x.DistortCorrect_ME: distortion correction with reverse phase encode map and topup for use with multi-echo data
- x.DistortCorrect_FUGUE_ME: distortion correction with Siemens field map for use with multi-echo data, in combination with x.PreProc_fmapPrep and x.PreProc_TissueReg_func2anat_fmap